### PR TITLE
Update argument name expected by the dash package

### DIFF
--- a/jupyter_plotly_dash/dash_wrapper.py
+++ b/jupyter_plotly_dash/dash_wrapper.py
@@ -211,13 +211,13 @@ class JupyterDash:
             dapp.index()
             # Endpoint is dash-component-suites/package_name/path_in_package
             try:
-                mFunc = dapp.locate_endpoint_function('dash-component-suites/<string:package_name>/<path:path_in_package_dist>')
+                mFunc = dapp.locate_endpoint_function('dash-component-suites/<string:package_name>/<path:fingerprinted_path>')
             except Exception as e:
                 return ("<html><body>Requested %s at %s with %s and failed with %s</body></html>" %(args,app_path,view_name_parts,e),"text/html")
             # Need two arguments here: package_name and path_in_package_dist
             package_name = view_name_parts[1]
             path_in_package_dist = "/".join(view_name_parts[2:])
             resp = mFunc(package_name=package_name,
-                         path_in_package_dist=path_in_package_dist)
+                         fingerprinted_path=path_in_package_dist)
             return (resp.data.decode('utf-8'), resp.mimetype)
 


### PR DESCRIPTION
From dash 1.11.0 "fingerprinted_path" name is used instead of "path_in_package_dist"